### PR TITLE
Adding readme under parser and parser/src

### DIFF
--- a/parser/README.md
+++ b/parser/README.md
@@ -13,41 +13,9 @@ We wrote [a blog post](https://rustpython.github.io/featured/2020/03/11/thing-ex
 For more information on LALRPOP, here is a link to the [LALRPOP book](https://github.com/lalrpop/lalrpop).
 
 
-## Files in `parser/src`
+## Files
 
-`lib.rs`  
-This is the crate's root.
-
-`lexer.rs`  
-This module takes care of lexing python source text. This means source code is translated into separate tokens.
-
-`parser.rs`   
-A python parsing module. Use this module to parse python code into an AST. There are three ways to parse python code. You could parse a whole program, a single statement, or a single expression.
-
-`ast.rs`  
-Implements abstract syntax tree (AST) nodes for the python language. Roughly equivalent to [the python AST](https://docs.python.org/3/library/ast.html).
-
-`python.lalrpop`  
-Python grammar.
-
-`token.rs`
-Different token definitions. Loosely based on token.h from CPython source.
-
-`errors.rs`  
-Define internal parse error types. The goal is to provide a matching and a safe error API, masking errors from LALR.
-
-`fstring.rs`   
-Format strings.
-
-`function.rs`  
-Collection of functions for parsing parameters, arguments.
-
-`location.rs`   
-Datatypes to support source location information.
-
-`mode.rs`   
-Execution mode check. Allowed modes are `exec`, `eval` or `single`.
-
+There is a readme in `parser/src` with the details of each file.
 
 ## How to use
 

--- a/parser/README.md
+++ b/parser/README.md
@@ -1,40 +1,52 @@
-# parser
-In this directory, you will find the code for python lexing, parsing and for generating Abstract Syntax Trees (AST).
+# RustPython/parser
 
-The stages involved in this process are:
+This directory has the code for python lexing, parsing and generating Abstract Syntax Trees (AST).
+
+The steps are:
 - Lexical analysis: splits the source code into tokens.
 - Parsing and generating the AST: transforms those tokens into an AST. Uses `LALRPOP`, a Rust parser generator framework.
 
-This crate is on [https://docs.rs/rustpython-parser](https://docs.rs/rustpython-parser). Check the link for documentation and to see a list with all of its items.
+This crate is published on [https://docs.rs/rustpython-parser](https://docs.rs/rustpython-parser).
 
-We wrote [a blog post](https://rustpython.github.io/featured/2020/03/11/thing-explainer-parser.html) with screenshots and an explanation to help you understand the parsing process by seeing it in action. Check it out!
+We wrote [a blog post](https://rustpython.github.io/featured/2020/03/11/thing-explainer-parser.html) with screenshots and an explanation to help you understand the steps by seeing them in action.
 
-For more information on LALRPOP, here is a link to a [LALRPOP book](https://github.com/lalrpop/lalrpop).
+For more information on LALRPOP, here is a link to the [LALRPOP book](https://github.com/lalrpop/lalrpop).
 
 
 ## Files in `parser/src`
 
-`lib.rs`: This is the crate's root.
+`lib.rs`  
+This is the crate's root.
 
-`lexer.rs:` This module takes care of lexing python source text. This means source code is translated into separate tokens.
+`lexer.rs`  
+This module takes care of lexing python source text. This means source code is translated into separate tokens.
 
-`parser.rs`: A python parsing module. Use this module to parse python code into an AST. There are three ways to parse python code. You could parse a whole program, a single statement, or a single expression.
+`parser.rs`   
+A python parsing module. Use this module to parse python code into an AST. There are three ways to parse python code. You could parse a whole program, a single statement, or a single expression.
 
-`ast.rs`:  Implements abstract syntax tree (AST) nodes for the python language. Roughly equivalent to [the python AST](https://docs.python.org/3/library/ast.html).
+`ast.rs`  
+Implements abstract syntax tree (AST) nodes for the python language. Roughly equivalent to [the python AST](https://docs.python.org/3/library/ast.html).
 
-`python.lalrpop`: Python grammar.
+`python.lalrpop`  
+Python grammar.
 
-`token.rs`: Different token definitions. Loosely based on token.h from CPython source.
+`token.rs`
+Different token definitions. Loosely based on token.h from CPython source.
 
-`errors.rs`: Define internal parse error types. The goal is to provide a matching and a safe error API, masking errors from LALR.
+`errors.rs`  
+Define internal parse error types. The goal is to provide a matching and a safe error API, masking errors from LALR.
 
-`fstring.rs`: Format strings.
+`fstring.rs`   
+Format strings.
 
-`function.rs`: Collection of functions for parsing parameters, arguments.
+`function.rs`  
+Collection of functions for parsing parameters, arguments.
 
-`location.rs`: Datatypes to support source location information.
+`location.rs`   
+Datatypes to support source location information.
 
-`mode.rs`: Execution mode check. Allowed modes are `exec`, `eval` or `single`.
+`mode.rs`   
+Execution mode check. Allowed modes are `exec`, `eval` or `single`.
 
 
 ## How to use

--- a/parser/README.md
+++ b/parser/README.md
@@ -1,0 +1,47 @@
+# parser
+In this directory, you will find the code for python lexing, parsing and for generating Abstract Syntax Trees (AST).
+
+The stages involved in this process are:
+- Lexical analysis: splits the source code into tokens.
+- Parsing and generating the AST: transforms those tokens into an AST. Uses `LALRPOP`, a Rust parser generator framework.
+
+This crate is on [https://docs.rs/rustpython-parser](https://docs.rs/rustpython-parser). Check the link for documentation and to see a list with all of its items.
+
+We wrote [a blog post](https://rustpython.github.io/featured/2020/03/11/thing-explainer-parser.html) with screenshots and an explanation to help you understand the parsing process by seeing it in action. Check it out!
+
+For more information on LALRPOP, here is a link to a [LALRPOP book](https://github.com/lalrpop/lalrpop).
+
+
+## Files in `parser/src`
+
+`lib.rs`: This is the crate's root.
+
+`lexer.rs:` This module takes care of lexing python source text. This means source code is translated into separate tokens.
+
+`parser.rs`: A python parsing module. Use this module to parse python code into an AST. There are three ways to parse python code. You could parse a whole program, a single statement, or a single expression.
+
+`ast.rs`:  Implements abstract syntax tree (AST) nodes for the python language. Roughly equivalent to [the python AST](https://docs.python.org/3/library/ast.html).
+
+`python.lalrpop`: Python grammar.
+
+`token.rs`: Different token definitions. Loosely based on token.h from CPython source.
+
+`errors.rs`: Define internal parse error types. The goal is to provide a matching and a safe error API, masking errors from LALR.
+
+`fstring.rs`: Format strings.
+
+`function.rs`: Collection of functions for parsing parameters, arguments.
+
+`location.rs`: Datatypes to support source location information.
+
+`mode.rs`: Execution mode check. Allowed modes are `exec`, `eval` or `single`.
+
+
+## How to use
+
+For example, one could do this:
+```
+  use rustpython_parser::{parser, ast};
+  let python_source = "print('Hello world')";
+  let python_ast = parser::parse_expression(python_source).unwrap();
+```

--- a/parser/README.md
+++ b/parser/README.md
@@ -12,10 +12,7 @@ We wrote [a blog post](https://rustpython.github.io/featured/2020/03/11/thing-ex
 
 For more information on LALRPOP, here is a link to the [LALRPOP book](https://github.com/lalrpop/lalrpop).
 
-
-## Files
-
-There is a readme in `parser/src` with the details of each file.
+There is a readme in the `src` folder with the details of each file.
 
 ## How to use
 

--- a/parser/src/README.md
+++ b/parser/src/README.md
@@ -1,23 +1,23 @@
 # RustPython/parser/src
 
-`lib.rs`: This is the crate's root.
+**lib.rs**: This is the crate's root.
 
-`lexer.rs` This module takes care of lexing python source text. This means source code is translated into separate tokens.
+**lexer.rs** This module takes care of lexing python source text. This means source code is translated into separate tokens.
 
-`parser.rs`: A python parsing module. Use this module to parse python code into an AST. There are three ways to parse python code. You could parse a whole program, a single statement, or a single expression.
+**parser.rs**: A python parsing module. Use this module to parse python code into an AST. There are three ways to parse python code. You could parse a whole program, a single statement, or a single expression.
 
-`ast.rs`:  Implements abstract syntax tree (AST) nodes for the python language. Roughly equivalent to [the python AST](https://docs.python.org/3/library/ast.html).
+**ast.rs**:  Implements abstract syntax tree (AST) nodes for the python language. Roughly equivalent to [the python AST](https://docs.python.org/3/library/ast.html).
 
-`python.lalrpop`: Python grammar.
+**python.lalrpop**: Python grammar.
 
-`token.rs`: Different token definitions. Loosely based on token.h from CPython source.
+**token.rs**: Different token definitions. Loosely based on token.h from CPython source.
 
-`errors.rs`: Define internal parse error types. The goal is to provide a matching and a safe error API, masking errors from LALR.
+**errors.rs**: Define internal parse error types. The goal is to provide a matching and a safe error API, masking errors from LALR.
 
-`fstring.rs`: Format strings.
+**fstring.rs**: Format strings.
 
-`function.rs`: Collection of functions for parsing parameters, arguments.
+**function.rs**: Collection of functions for parsing parameters, arguments.
 
-`location.rs`: Datatypes to support source location information.
+**location.rs**: Datatypes to support source location information.
 
-`mode.rs`: Execution mode check. Allowed modes are `exec`, `eval` or `single`.
+**mode.rs**: Execution mode check. Allowed modes are `exec`, `eval` or `single`.

--- a/parser/src/README.md
+++ b/parser/src/README.md
@@ -1,23 +1,34 @@
 # RustPython/parser/src
 
-**lib.rs**: This is the crate's root.
+**lib.rs**   
+This is the crate's root.
 
-**lexer.rs** This module takes care of lexing python source text. This means source code is translated into separate tokens.
+**lexer.rs**   
+This module takes care of lexing python source text. This means source code is translated into separate tokens.
 
-**parser.rs**: A python parsing module. Use this module to parse python code into an AST. There are three ways to parse python code. You could parse a whole program, a single statement, or a single expression.
+**parser.rs**   
+A python parsing module. Use this module to parse python code into an AST. There are three ways to parse python code. You could parse a whole program, a single statement, or a single expression.
 
-**ast.rs**:  Implements abstract syntax tree (AST) nodes for the python language. Roughly equivalent to [the python AST](https://docs.python.org/3/library/ast.html).
+**ast.rs**   
+ Implements abstract syntax tree (AST) nodes for the python language. Roughly equivalent to [the python AST](https://docs.python.org/3/library/ast.html).
 
-**python.lalrpop**: Python grammar.
+**python.lalrpop**   
+Python grammar.
 
-**token.rs**: Different token definitions. Loosely based on token.h from CPython source.
+**token.rs**   
+Different token definitions. Loosely based on token.h from CPython source.
 
-**errors.rs**: Define internal parse error types. The goal is to provide a matching and a safe error API, masking errors from LALR.
+**errors.rs**   
+Define internal parse error types. The goal is to provide a matching and a safe error API, masking errors from LALR.
 
-**fstring.rs**: Format strings.
+**fstring.rs**   
+Format strings.
 
-**function.rs**: Collection of functions for parsing parameters, arguments.
+**function.rs**   
+Collection of functions for parsing parameters, arguments.
 
-**location.rs**: Datatypes to support source location information.
+**location.rs**   
+Datatypes to support source location information.
 
-**mode.rs**: Execution mode check. Allowed modes are `exec`, `eval` or `single`.
+**mode.rs**   
+Execution mode check. Allowed modes are `exec`, `eval` or `single`.

--- a/parser/src/README.md
+++ b/parser/src/README.md
@@ -1,0 +1,23 @@
+# RustPython/parser/src
+
+`lib.rs`: This is the crate's root.
+
+`lexer.rs` This module takes care of lexing python source text. This means source code is translated into separate tokens.
+
+`parser.rs`: A python parsing module. Use this module to parse python code into an AST. There are three ways to parse python code. You could parse a whole program, a single statement, or a single expression.
+
+`ast.rs`:  Implements abstract syntax tree (AST) nodes for the python language. Roughly equivalent to [the python AST](https://docs.python.org/3/library/ast.html).
+
+`python.lalrpop`: Python grammar.
+
+`token.rs`: Different token definitions. Loosely based on token.h from CPython source.
+
+`errors.rs`: Define internal parse error types. The goal is to provide a matching and a safe error API, masking errors from LALR.
+
+`fstring.rs`: Format strings.
+
+`function.rs`: Collection of functions for parsing parameters, arguments.
+
+`location.rs`: Datatypes to support source location information.
+
+`mode.rs`: Execution mode check. Allowed modes are `exec`, `eval` or `single`.


### PR DESCRIPTION
Adding readme files under  `parser` and `parser/src` to make it faster to figure out the files and what each does.